### PR TITLE
start Redis only when needed (to send email)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,11 +28,11 @@ export DATABASE_URL=postgresql://fittrackee:fittrackee@fittrackee-db:5432/fittra
 # Emails
 # since fittrackee 0.6.5, email sending can be disabled
 # see documentation https://samr1.github.io/FitTrackee/installation.html#emails
-export UI_URL=
-export EMAIL_URL=
-export SENDER_EMAIL=
-export REDIS_URL=redis://redis:6379
-export WORKERS_PROCESSES=2
+#export UI_URL=
+#export EMAIL_URL=
+#export SENDER_EMAIL=
+#export REDIS_URL=redis://redis:6379
+#export WORKERS_PROCESSES=2
 
 # Activities
 #export TILE_SERVER_URL=

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,16 @@ migrate:
 rebuild:
 	docker-compose build --no-cache
 
+redis:
+	docker-compose up -d redis
+
 restart:
-	# Restart fittrackee
 	docker-compose restart fittrackee
 
-run-all: run run-workers
+run-all: redis run run-workers
 
 run:
-	docker-compose up -d
+	docker-compose up -d fittrackee
 
 run-workers:
 	docker-compose exec -d fittrackee scripts/run-workers.sh
@@ -34,7 +36,8 @@ set-admin:
 	docker-compose exec fittrackee scripts/set-admin.sh $(USERNAME)
 
 stop:
-	docker-compose stop
+	docker-compose stop fittrackee fittrackee-db
+	docker-compose stop redis
 
 up:
 	docker-compose up

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Docker sample to install FitTrackee
 Open http://localhost:5000 and register.
 
 - To set admin rights to the newly created account, use the following command:
+  **Note**: it also activates account.
 
 ```bash
    $ make set-admin USERNAME=<username>
@@ -32,17 +33,19 @@ Open http://localhost:5000 and register.
     $ make stop
 ```
 
-- To start **Fittrackee** (application and dramatiq workers):
+- To start **Fittrackee**:
+
+```bash
+    $ make run
+```
+
+- To start **Fittrackee** application and dramatiq workers (with Redis):
 
 ```bash
     $ make run-all
 ```
 
-- To run shell inside **Fittrackee** container:
-
-```bash
-    $ make shell
-```
+  **Warning**: `EMAIL_URL` must be initialized to send emails.
 
 - To update **FitTrackee**
 
@@ -50,6 +53,13 @@ Open http://localhost:5000 and register.
     $ make update migrate 
 ```
 
+- To run shell inside **Fittrackee** container (with virtualenv):
+
+```bash
+    $ make shell
+```
+
+
 Notes:
-- **Important**: all uncommented variables present in .env should be initialized. Otherwise, the application may not start.
+- **Important**: all uncommented variables present in .env must be initialized. Otherwise, the application may not start.
 - If you just want to evaluate **FitTrackee**, ready to use docker files are available in **FitTrackee** repository (see [Documentation](https://samr1.github.io/FitTrackee/installation.html#docker)).

--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@ Open http://localhost:5000 and register.
     $ make stop
 ```
 
-- To start **Fittrackee**:
+- To start **Fittrackee** application:
 
 ```bash
     $ make run
 ```
 
-- To start **Fittrackee** application and dramatiq workers (with Redis):
+- To start **Fittrackee** application and dramatiq workers (with Redis) in order to send emails:
 
 ```bash
     $ make run-all
 ```
 
-  **Warning**: `EMAIL_URL` must be initialized to send emails.
+  **Warning**: `EMAIL_URL` must be initialized.
 
 - To update **FitTrackee**
 
@@ -61,5 +61,5 @@ Open http://localhost:5000 and register.
 
 
 Notes:
-- **Important**: all uncommented variables present in .env must be initialized. Otherwise, the application may not start.
+- **Important**: all uncommented [variables](https://samr1.github.io/FitTrackee/installation.html#environment-variables) present in .env must be initialized. Otherwise, the application may not start.
 - If you just want to evaluate **FitTrackee**, ready to use docker files are available in **FitTrackee** repository (see [Documentation](https://samr1.github.io/FitTrackee/installation.html#docker)).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,8 @@ services:
       - .env
     depends_on:
       - fittrackee-db
-      - redis
     links:
       - fittrackee-db
-      - redis
     volumes:
       - fittrackee_upload:/uploads:rw
       - type: bind
@@ -33,7 +31,7 @@ services:
     image: "redis:latest"
     hostname: redis
     ports:
-      - 6379:6379
+      - "6379:6379"
 
 volumes:
   fittrackee_upload:

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -3,5 +3,6 @@ set -e
 cd /usr/src/app
 
 source .env
+source .venv/bin/activate
 
 /bin/bash


### PR DESCRIPTION
Email sending can be now disabled (see [v.0.6.5](https://github.com/SamR1/FitTrackee/releases/tag/v0.6.5)).

In this case, no need to start Redis and dramatiq workers.


