### PR TITLE
update .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,13 @@ DATABASE_URL=postgresql://fittrackee:fittrackee@fittrackee-db:5432/fittrackee
 #SENDER_EMAIL=
 #WORKERS_PROCESSES=2
 
-# Activities
-#TILE_SERVER_URL=
-#MAP_ATTRIBUTION=
-#WEATHER_API_KEY=
+# Workouts
+#export TILE_SERVER_URL=
+#export STATICMAP_SUBDOMAINS=
+#export MAP_ATTRIBUTION=
+#export DEFAULT_STATICMAP=False
+
+# Weather
+# available weather API providers: darksky, visualcrossing
+#export WEATHER_API_PROVIDER=
+#export WEATHER_API_KEY=


### PR DESCRIPTION
- add new env variable `WEATHER_API_PROVIDER` introduced in [v0.7.11](https://github.com/SamR1/FitTrackee/releases/tag/v0.7.11)
- add missing env variables related to maps (`STATICMAP_SUBDOMAINS`, `DEFAULT_STATICMAP`)