### PR TITLE
start application and workers with supervisor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ POSTGRES_PASSWORD=postgres
 DATABASE_URL=postgresql://fittrackee:fittrackee@fittrackee-db:5432/fittrackee
 #DATABASE_DISABLE_POOLING=
 
-# Redis (required for API rate limits and email sending)
+# Redis (required for API rate limits, email sending and user export)
 #REDIS_URL=redis://redis:6379
 
 # API rate limits (needs redis running)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.9
 
 MAINTAINER SamR1@users.noreply.github.com
 
+RUN apt-get update && apt-get -y install supervisor
+
 # set working directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -9,6 +11,12 @@ WORKDIR /usr/src/app
 # copy needed files
 COPY scripts/ /usr/src/app/scripts
 COPY .env /usr/src/app
+COPY docker-entrypoint.sh /usr/src/app
+COPY supervisor/ /usr/src/app/supervisor
+
+RUN ln -s /usr/src/app/supervisor/fittrackee.supervisor.conf /etc/supervisor/conf.d/fittrackee.supervisor.conf
+RUN ln -s /usr/src/app/supervisor/fittrackee-workers.supervisor.conf /etc/supervisor/conf.d/fittrackee-workers.supervisor.conf
+
 
 # install fittrackee from pip
 ENV VIRTUAL_ENV=/usr/src/app/.venv
@@ -25,5 +33,5 @@ ARG GUNICORN_TIMEOUT
 ARG GUNICORN_LOG
 ARG GUNICORN_THREADS
 
-# run fittrackee server w/ gunicorn
-CMD $VIRTUAL_ENV/bin/gunicorn -b 0.0.0.0:5000 "fittrackee:create_app()" --error-logfile $GUNICORN_LOG --timeout $GUNICORN_TIMEOUT --workers=$APP_WORKERS --threads=$GUNICORN_THREADS --worker-class=gthread
+# run supervisor
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 build:
 	docker-compose build
 
-init: migrate restart
+init: up migrate run
 
 logs:
 	docker-compose logs --follow
@@ -19,15 +19,19 @@ redis:
 	docker-compose up -d redis
 
 restart:
-	docker-compose restart fittrackee
+	docker-compose exec fittrackee supervisorctl restart fittrackee
 
-run-all: run run-workers
+run-all:
+	# start fittrackee web application and fittrackee workers
+	docker-compose exec fittrackee supervisorctl start all
 
-run:
-	docker-compose up -d fittrackee
+run: up
+	# start fittrackee web application
+	docker-compose exec fittrackee supervisorctl start fittrackee
 
-run-workers: redis
-	docker-compose exec -d fittrackee scripts/run-workers.sh
+run-workers: up redis
+	# start fittrackee workers
+	docker-compose exec fittrackee supervisorctl start fittrackee-workers
 
 shell:
 	docker-compose exec fittrackee scripts/shell.sh
@@ -39,8 +43,11 @@ stop:
 	docker-compose stop fittrackee fittrackee-db
 	docker-compose stop redis
 
+stop-all:
+	docker-compose exec fittrackee supervisorctl stop all
+
 up:
-	docker-compose up
+	docker-compose up -d
 
 update:
 	docker-compose exec fittrackee scripts/update-fittrackee.sh

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Docker sample to install FitTrackee
   $ cp .env.example .env
   $ mkdir [FITTRACKEE_LOG_DIR]  # create a directory to store fittrackee logs
   $ $EDITOR .env  # update environment variables (see Documentation)
-  $ make build run init
+  $ make build up init
 ```
 
 With default configuration (no `EMAIL_URL` set), email sending is disabled.
@@ -29,10 +29,16 @@ With default configuration (no `EMAIL_URL` set), email sending is disabled.
    $ make set-admin USERNAME=<username>
 ```
 
-- To stop **Fittrackee**:
+- To stop docker containers:
 
 ```bash
     $ make stop
+```
+
+- To start docker containers:
+
+```bash
+    $ make up
 ```
 
 - To start **Fittrackee** application:
@@ -52,7 +58,9 @@ With default configuration (no `EMAIL_URL` set), email sending is disabled.
 - To update **FitTrackee**
 
 ```bash
+    $ make stop-all
     $ make update migrate 
+    $ make run-all  # after checking update and migration went well
 ```
 
 - To run shell inside **Fittrackee** container (with virtualenv):

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+cd /usr/src/app
+
+source .env
+
+supervisord -n

--- a/scripts/run-workers.sh
+++ b/scripts/run-workers.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-cd /usr/src/app
-
-source .env
-
-.venv/bin/flask worker --processes $WORKERS_PROCESSES

--- a/supervisor/fittrackee-workers.supervisor.conf
+++ b/supervisor/fittrackee-workers.supervisor.conf
@@ -1,0 +1,5 @@
+[program:fittrackee-workers]
+command = .venv/bin/flask worker --processes %(ENV_WORKERS_PROCESSES)s
+
+autostart = false
+autorestart = false

--- a/supervisor/fittrackee.supervisor.conf
+++ b/supervisor/fittrackee.supervisor.conf
@@ -1,0 +1,5 @@
+[program:fittrackee]
+command = .venv/bin/gunicorn -b 0.0.0.0:5000 "fittrackee:create_app()" --error-logfile %(ENV_GUNICORN_LOG)s --timeout %(ENV_GUNICORN_TIMEOUT)s --workers=%(ENV_APP_WORKERS)s --threads=%(ENV_GUNICORN_THREADS)s --worker-class=gthread
+
+autostart = false
+autorestart = false


### PR DESCRIPTION
Add `supervisor` to start and stop **FitTrackee** web application and workers easily (especially before upgrade and migration).