### PR TITLE
Fix .env default config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,14 @@
 FITTRACKEE_LOG_DIR=
 
 # Application
+# directories are located in the docker container
 FLASK_APP=fittrackee
 FLASK_SKIP_DOTENV=1
 PORT=5000
 APP_SETTINGS=fittrackee.config.ProductionConfig
 APP_SECRET_KEY='please change me'
 APP_LOG=/logs/fittrackee.log
-UPLOAD_FOLDER=/uploads
+UPLOAD_FOLDER=/uploads  # must match docker-compose config
 # gunicorn settings
 # see https://docs.gunicorn.org/en/stable/settings.html#worker-processes
 APP_WORKERS=2

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ APP_WORKERS=2
 GUNICORN_LOG=/logs/gunicorn.log
 GUNICORN_TIMEOUT=300
 GUNICORN_THREADS=4
+# workers settings
+WORKERS_PROCESSES=2
 
 # PostgreSQL
 POSTGRES_USER=postgres
@@ -37,7 +39,6 @@ DATABASE_URL=postgresql://fittrackee:fittrackee@fittrackee-db:5432/fittrackee
 #UI_URL=
 #EMAIL_URL=
 #SENDER_EMAIL=
-#WORKERS_PROCESSES=2
 
 # Workouts
 #export TILE_SERVER_URL=

--- a/README.md
+++ b/README.md
@@ -73,3 +73,15 @@ With default configuration (no `EMAIL_URL` set), email sending is disabled.
 Notes:
 - **Important**: all uncommented [variables](https://samr1.github.io/FitTrackee/installation.html#environment-variables) present in .env must be initialized. Otherwise, the application may not start.
 - If you just want to evaluate **FitTrackee**, ready to use docker files are available in **FitTrackee** repository (see [Documentation](https://samr1.github.io/FitTrackee/installation.html#docker)).
+
+Troubleshooting:
+- If installation or startup fails, check the environnement variables.  
+- The commands can be run separately when debugging, for instance:
+```shell
+$ make build
+$ make up
+$ make migrate
+$ make run
+```
+
+`make up` can be replaced with `docker-compose up` (without `detach` option to prevent containers from running in background and to display some errors).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Notes:
 - If you just want to evaluate **FitTrackee**, ready to use docker files are available in **FitTrackee** repository (see [Documentation](https://samr1.github.io/FitTrackee/installation.html#docker)).
 
 Troubleshooting:
-- If installation or startup fails, check the environnement variables.  
+- If installation or startup fails, check the environment variables.  
 - The commands can be run separately when debugging, for instance:
 ```shell
 $ make build


### PR DESCRIPTION
`WORKERS_PROCESSES` must always be exposed, even workers are not running (when email sending is disabled for instance).  
If not, `supervisor` will fail to start.

fix  #29 